### PR TITLE
Perform environment variable substitution by default (fixes #8)

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -370,6 +370,24 @@ ENV e=\"f g\"
                           "LABEL TEST={0}\n".format(label)]
         assert dfparser.labels['TEST'] == expected
 
+    @pytest.mark.parametrize(('label', 'expected'), [
+        # These would have been substituted with env_replace=True
+        ('$V', '$V'),
+        ('"$V"', '$V'),
+        ('$V-foo', '$V-foo'),
+        ('"$V-foo"', '$V-foo'),
+        ('"$V"-foo', '$V-foo'),
+    ])
+    def test_env_noreplace(self, dfparser, label, expected):
+        """
+        Make sure environment replacement can be disabled.
+        """
+        dfparser.env_replace = False
+        dfparser.lines = ["FROM fedora\n",
+                          "ENV V=v\n",
+                          "LABEL TEST={0}\n".format(label)]
+        assert dfparser.labels['TEST'] == expected
+
     @pytest.mark.parametrize('label', [
         '${V',
         '"${V"',


### PR DESCRIPTION
I've added a new class `EnvSubst` for doing environment variable substitution when quoting allows, as this doesn't seem to be possible/easy with other approaches I investigated (subclassing `shlex.shlex`, using `string.Template`, using `os.path.expandvar()`).

The `shlex_split()` function now has keyword arguments for performing environment substitution.

The instructions getter method now always tracks `ENV` in order to build an environment variable dictionary with which to perform substitution.

The `DockerfileParser` constructor now takes a keyword argument `env_replace` to specify whether to perform substitution. An instance variable of the same name can be set after construction for the same effect.