### PR TITLE
README: add more examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ $ sudo pip install .
 ```python
 from pprint import pprint
 from dockerfile_parse import DockerfileParser
-dfp=DockerfileParser()
+
+dfp = DockerfileParser()
 dfp.content = """\
 From  base
 LABEL foo="bar baz"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,15 @@ dfp.content = """\
 From  base
 LABEL foo="bar baz"
 USER  me"""
+
+# Print the parsed structure:
 pprint(dfp.structure)
 pprint(dfp.json)
 pprint(dfp.labels)
+
+# Set a new base:
+dfp.baseimage = 'centos:7'
+
+# Print the new Dockerfile with an updated FROM line:
+print(dfp.content)
 ```


### PR DESCRIPTION
Fix the flake8 warnings in the README's example, and add a couple more
examples (setting a new base image, printing the resulting Dockerfile)