### PR TITLE
Add ability to use a file-like object instead of path

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/dockerfile_parse/parser.py
+++ b/dockerfile_parse/parser.py
@@ -79,6 +79,10 @@ class DockerfileParser(object):
         :param parent_env: python dict of inherited env vars from parent image
         :param fileobj: file-like object containing Dockerfile content
         """
+
+        if path is not None and fileobj is not None:
+            raise ValueError("Parameters path and fileobj cannot be used together.")
+
         path = path or '.'
         if path.endswith(DOCKERFILE_FILENAME):
             self.dockerfile_path = path

--- a/dockerfile_parse/parser.py
+++ b/dockerfile_parse/parser.py
@@ -119,6 +119,8 @@ class DockerfileParser(object):
     def _open_dockerfile(self, mode):
         if self.fileobj is not None:
             self.fileobj.seek(0)
+            if mode == 'w':
+                self.fileobj.truncate()
             yield self.fileobj
             self.fileobj.seek(0)
         else:

--- a/dockerfile_parse/parser.py
+++ b/dockerfile_parse/parser.py
@@ -73,11 +73,11 @@ class DockerfileParser(object):
                  parent_env=None,
                  fileobj=None):
         """
-        Initialize path to Dockerfile
+        Initialize source of Dockerfile
         :param path: path to (directory with) Dockerfile
         :param cache_content: cache Dockerfile content inside DockerfileParser
         :param parent_env: python dict of inherited env vars from parent image
-        :param fileobj: file-like object used to cache content of Dockerfile
+        :param fileobj: file-like object containing Dockerfile content
         """
         path = path or '.'
         if path.endswith(DOCKERFILE_FILENAME):
@@ -110,8 +110,19 @@ class DockerfileParser(object):
     @contextmanager
     def _open_dockerfile(self, mode):
         if self.fileobj is not None:
-            self.fileobj.seek(0)
+            try:
+                self.fileobj.seek(0)
+            except IOError:
+                # not seekable fileobj
+                pass
+
             yield self.fileobj
+
+            try:
+                self.fileobj.seek(0)
+            except IOError:
+                # not seekable fileobj
+                pass
         else:
             with open(self.dockerfile_path, mode) as dockerfile:
                 yield dockerfile

--- a/dockerfile_parse/parser.py
+++ b/dockerfile_parse/parser.py
@@ -77,7 +77,7 @@ class DockerfileParser(object):
         :param path: path to (directory with) Dockerfile
         :param cache_content: cache Dockerfile content inside DockerfileParser
         :param parent_env: python dict of inherited env vars from parent image
-        :param fileobj: seekable file-like object containing Dockerfile content
+        :param fileobj: seekable file-like object containing Dockerfile content (will be truncated on write)
         """
 
         self.fileobj = fileobj

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -10,11 +10,12 @@ of the BSD license. See the LICENSE file for details.
 from __future__ import unicode_literals
 
 import pytest
+import six
 
 from dockerfile_parse import DockerfileParser
 
 
-@pytest.fixture(params=[False, True])
+@pytest.fixture(params=[(dockerfile, cache_content) for dockerfile in ['fileobj', 'path'] for cache_content in [True, False]])
 def dfparser(tmpdir, request):
     """
 
@@ -22,8 +23,13 @@ def dfparser(tmpdir, request):
     :param request: parameter, cache_content arg to DockerfileParser
     :return: DockerfileParser instance
     """
-    tmpdir_path = str(tmpdir.realpath())
-    return DockerfileParser(tmpdir_path, request.param)
+
+    if request.param[1] == 'path':
+        tmpdir_path = str(tmpdir.realpath())
+        return DockerfileParser(path=tmpdir_path, cache_content=request.param[0])
+    else:
+        file = six.StringIO()
+        return DockerfileParser(fileobj=file, cache_content=request.param[0])
 
 
 @pytest.fixture(params=['LABEL', 'ENV'])

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -15,7 +15,7 @@ import six
 from dockerfile_parse import DockerfileParser
 
 
-@pytest.fixture(params=[(dockerfile, cache_content) for dockerfile in ['fileobj', 'path'] for cache_content in [True, False]])
+@pytest.fixture(params=[(use_fileobj, cache_content) for use_fileobj in [True, False] for cache_content in [True, False]])
 def dfparser(tmpdir, request):
     """
 
@@ -24,12 +24,14 @@ def dfparser(tmpdir, request):
     :return: DockerfileParser instance
     """
 
-    if request.param[1] == 'path':
-        tmpdir_path = str(tmpdir.realpath())
-        return DockerfileParser(path=tmpdir_path, cache_content=request.param[0])
-    else:
+    use_fileobj, cache_content = request.param
+    if use_fileobj:
         file = six.StringIO()
-        return DockerfileParser(fileobj=file, cache_content=request.param[0])
+        return DockerfileParser(fileobj=file, cache_content=cache_content)
+    else:
+        tmpdir_path = str(tmpdir.realpath())
+        return DockerfileParser(path=tmpdir_path, cache_content=cache_content)
+
 
 
 @pytest.fixture(params=['LABEL', 'ENV'])

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,1 +1,2 @@
 pytest
+six

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -11,6 +11,8 @@ from __future__ import unicode_literals
 
 import json
 import pytest
+import six
+import sys
 
 from dockerfile_parse import DockerfileParser
 from tests.fixtures import dfparser, instruction
@@ -452,3 +454,13 @@ ENV e=\"f g\"
                           "ENV V=v\n",
                           "LABEL TEST={0}\n".format(label)]
         assert dfparser.labels['TEST'] == expected
+
+    def test_path_and_fileobj_together(self):
+        with pytest.raises(ValueError):
+            DockerfileParser(path='.', fileobj=six.StringIO())
+
+    def test_nonseekable_fileobj(self):
+        with pytest.raises(AttributeError):
+            DockerfileParser(fileobj=sys.stdin)
+
+


### PR DESCRIPTION
I have implemented a possibility to cache content with the file-like object. So, it won't be necessary to write `Dockerfile` to disk.

It adds a property `fileobj` to `parser`. If it is not `None`, the content will be written to this `fileobj` instead of the `./Dockerfile` file.

Here is an example of usage with StringIO:

```python
content = r"""
FROM fedora:latest
MAINTAINER Franta

ENV a=aaa
"""

dockerfile = six.StringIO(content)
dfp = dockerfile_parse.DockerfileParser(fileobj=dockerfile,
                                     cache_content=True,
                                     env_replace=False)
```

Can you please have a look at it?

Thanks