### PR TITLE
Labels and envs dict to structure

### DIFF
--- a/dockerfile_parse/util.py
+++ b/dockerfile_parse/util.py
@@ -9,8 +9,8 @@ of the BSD license. See the LICENSE file for details.
 
 from __future__ import print_function, unicode_literals
 
-from io import StringIO
 import shlex
+from io import StringIO
 
 from .constants import PY2
 
@@ -188,3 +188,102 @@ def remove_nonescaped_quotes(string):
     string = remove_quotes(string)
     string = string.replace('\ ', ' ')
     return string.replace("\\s", "'").replace('\\d', '"')  # restore
+
+
+def split_tuple(text):
+    text_split = text.split('=', 1)
+    if len(text_split) == 2:
+        return tuple(text_split)
+    return None
+
+
+def extract_labels_or_envs(env_replace, envs, instruction_value):
+    shlex_splits_raw = shlex_split(instruction_value,
+                                   env_replace=env_replace, envs=envs)
+
+    key_val_list = []
+    if '=' not in shlex_splits_raw[0]:  # LABEL/ENV name value
+        # split it to first (name) and the rest (value)
+        key_val = instruction_value.split(None, 1)
+        key = strip_quotes(key_val[0])
+        try:
+            val = key_val[1]
+        except IndexError:
+            val = ''
+
+        if env_replace:
+            val = EnvSubst(val, envs).substitute()
+        val = remove_nonescaped_quotes(val)
+
+        key_val_list.append((key, val))
+
+    else:  # LABEL/ENV "name"="value"
+
+        for k_v in shlex_splits_raw:
+            key_val_list.append(split_tuple(k_v))
+
+    return key_val_list
+
+
+def get_key_val_dictionary(instruction_value, env_replace=False, envs=None):
+    envs = envs or []
+    return dict(extract_labels_or_envs(instruction_value=instruction_value,
+                                       env_replace=env_replace,
+                                       envs=envs))
+
+
+class Context(object):
+    def __init__(self, envs=None, labels=None, line_envs=None, line_labels=None):
+        """
+        Class representing current state of environment variables and labels.
+
+        :param envs: dict with variables valid for this line
+            (all variables defined to this line)
+        :param labels: dict with labels valid for this line
+            (all labels defined to this line)
+        :param line_envs: dict with variables defined on this line
+        :param line_labels: dict with labels defined on this line
+        """
+        self.envs = envs or {}
+        self.labels = labels or {}
+        self.line_envs = line_envs or {}
+        self.line_labels = line_labels or {}
+
+    def set_line_value(self, context_type, value):
+        """
+        Set value defined on this line ('line_envs'/'line_labels')
+        and update 'envs'/'labels'.
+
+        :param context_type: "ENV" or "LABEL"
+        :param value: new value for this line
+        """
+        if context_type.upper() == "ENV":
+            self.line_envs = value
+            self.envs.update(value)
+        elif context_type.upper() == "LABEL":
+            self.line_labels = value
+            self.labels.update(value)
+
+    def get_line_value(self, context_type):
+        """
+        Get the values defined on this line.
+
+        :param context_type: "ENV" or "LABEL"
+        :return: values of given type defined on this line
+        """
+        if context_type.upper() == "ENV":
+            return self.line_envs
+        elif context_type.upper() == "LABEL":
+            return self.line_labels
+
+    def get_values(self, context_type):
+        """
+        Get the values valid on this line.
+
+        :param context_type: "ENV" or "LABEL"
+        :return: values of given type valid on this line
+        """
+        if context_type.upper() == "ENV":
+            return self.envs
+        elif context_type.upper() == "LABEL":
+            return self.labels


### PR DESCRIPTION
As well as @phracek in #28, I need to parse `ENV`/`LABEL` key-values for each instruction.

For a backwards compatibility, I've only added another item to instruction dictionary:
```Dockerfile
FROM fedora:25

LABEL summary="Postfix is a Mail Transport Agent (MTA)." \
       version="1.0" \
       description="Postfix is mail transfer agent that routes and delivers mail." \
       io.k8s.description="Postfix is mail transfer agent that routes and delivers mail." \
       io.k8s.display-name="Postfix 3.1" \
       io.openshift.expose-services="10025:postfix" \
io.openshift.tags="postfix,mail,mta"

```

```python
{
    u'startline': 2,
    u'dictionary': {u'io.k8s.description': u'Postfix is mail transfer agent that routes and delivers mail.',
                    u'description': u'Postfix is mail transfer agent that routes and delivers mail.',
                    u'io.k8s.display-name': u'Postfix 3.1',
                    u'summary': u'Postfix is a Mail Transport Agent (MTA).',
                    u'version': u'1.0',
                    u'io.openshift.expose-services': u'10025:postfix',
                    u'io.openshift.tags': u'postfix,mail,mta'},
    u'instruction': u'LABEL',
    u'value': u'summary="Postfix is a Mail Transport Agent (MTA)."        version="1.0"        description="Postfix is mail transfer agent that routes and delivers mail."        io.k8s.description="Postfix is mail transfer agent that routes and delivers mail."        io.k8s.display-name="Postfix 3.1"        io.openshift.expose-services="10025:postfix" io.openshift.tags="postfix,mail,mta"',
    u'content': u'LABEL summary="Postfix is a Mail Transport Agent (MTA)." \\\n       version="1.0" \\\n       description="Postfix is mail transfer agent that routes and delivers mail." \\\n       io.k8s.description="Postfix is mail transfer agent that routes and delivers mail." \\\n       io.k8s.display-name="Postfix 3.1" \\\n       io.openshift.expose-services="10025:postfix" \\\nio.openshift.tags="postfix,mail,mta"\n',
    u'endline': 8
}
```

There has been restructured/refactored the parsing function and added some basic tests.

What do you all think about it?
Thanks for any suggestions.

-----

I've also removed one test:

```diff
-        lines.insert(-1, '{0} "name1"=\'value 1\' "name2"=myself name3="" name4\n'.format(i))
+        lines.insert(-1, '{0} "name1"=\'value 1\' "name2"=myself name3=""\n'.format(i))

-        assert instructions.get('name4') == ''
```
 I am not sure, but this `ENV`/`LABEL` Dockerfile syntax is not valid:

`LABEL "name1"='value 1' "name2"=myself name3="" name4`

(missing value for `name4`)


