### PR TITLE
Do not overwrite multiple FROMs for multi-stage builds

### DIFF
--- a/dockerfile_parse/parser.py
+++ b/dockerfile_parse/parser.py
@@ -494,6 +494,8 @@ class DockerfileParser(object):
                 del lines[insn['startline']:insn['endline'] + 1]
                 lines.insert(insn['startline'], new_line)
                 self.lines = lines
+                if insn['instruction'] == 'FROM':  # Only overwrite first base-image
+                    return
 
     def _delete_instructions(self, instruction, value=None):
         """

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -228,6 +228,27 @@ class TestDockerfileParser(object):
         dfparser.cmd = CMD[1]
         assert dfparser.cmd == CMD[1]
 
+    def test_modify_from_multistage(self, dfparser):
+        FROM = ('base:${CODE_VERSION}', 'extras:${CODE_VERSION}')
+        CMD = ('/code/run-app', '/code/run-extras')
+        df_content = dedent("""\
+ARG  CODE_VERSION=latest
+FROM {0}
+CMD  {1}
+
+FROM {2}
+CMD  {3}""").format(FROM[0], CMD[0], FROM[1], CMD[1])
+
+        dfparser.content = df_content
+
+        assert dfparser.baseimage == FROM[0]
+        dfparser.baseimage = FROM[1]
+        assert dfparser.baseimage == FROM[1]
+
+        assert dfparser.cmd == CMD[1]
+        dfparser.cmd = CMD[0]
+        assert dfparser.cmd == CMD[0]
+
     def test_add_del_instruction(self, dfparser):
         df_content = dedent("""\
             CMD xyz


### PR DESCRIPTION
Hi,

Since 17.05 multiple FROMs are possible see
https://docs.docker.com/engine/reference/builder/#from

Maybe we want to make modifying all baseimage possible at alter stage, for now don't corrupt parsed Dockerfiles