### PR TITLE
Correctly expand concatenated variables

### DIFF
--- a/dockerfile_parse/util.py
+++ b/dockerfile_parse/util.py
@@ -95,31 +95,36 @@ class EnvSubst(object):
                 continue
 
             if ch == '$' and self.quotes != self.SQUOTE:
-                # Substitute environment variable
-                braced = False
-                varname = ''
                 while True:
-                    ch = self.stream.read(1)
-                    if varname == '' and ch == '{':
-                        braced = True
-                        continue
+                    # Substitute environment variable
+                    braced = False
+                    varname = ''
+                    while True:
+                        ch = self.stream.read(1)
+                        if varname == '' and ch == '{':
+                            braced = True
+                            continue
 
-                    if not ch:
-                        # EOF
+                        if not ch:
+                            # EOF
+                            break
+
+                        if braced and ch == '}':
+                            break
+
+                        if not ch.isalnum() and ch != '_':
+                            break
+
+                        varname += ch
+
+                    try:
+                        yield self.envs[varname]
+                    except KeyError:
+                        pass
+
+                    # Check whether there is another envvar
+                    if ch != '$':
                         break
-
-                    if braced and ch == '}':
-                        break
-
-                    if not ch.isalnum() and ch != '_':
-                        break
-
-                    varname += ch
-
-                try:
-                    yield self.envs[varname]
-                except KeyError:
-                    pass
 
                 if braced and ch == '}':
                     continue

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -686,3 +686,11 @@ class TestDockerfileParser(object):
 
         assert c[3].get_values(context_type="ENV") == {"key": "value"}
         assert c[3].get_values(context_type="LABEL") == {"key2": "value2"}
+
+    def test_expand_concatenated_variables(self, dfparser):
+        dfparser.content = dedent("""
+            FROM scratch
+            ENV NAME=name VER=1
+            LABEL component="$NAME$VER"
+        """)
+        assert dfparser.labels['component'] == 'name1'


### PR DESCRIPTION
Moved the environment variable substitution into a while loop that runs until the next character is not '$'.

Fixes: #44 