### PR TITLE
Fixes #28: add exception KeyError

### DIFF
--- a/dockerfile_parse/parser.py
+++ b/dockerfile_parse/parser.py
@@ -341,12 +341,16 @@ class DockerfileParser(object):
                 key_val_list = extract_labels_or_envs(env_replace=env_replace,
                                                       envs=envs,
                                                       instruction_value=instruction_desc['value'])
-                for key, value in key_val_list:
-                    if this_instruction == name:
-                        instructions[key] = value
-                        logger.debug("new %s %r=%r", name.lower(), key, value)
-                    if this_instruction == 'ENV':
-                        envs[key] = value
+                try:
+                    for key, value in key_val_list:
+                        if this_instruction == name:
+                            instructions[key] = value
+                            logger.debug("new %s %r=%r", name.lower(), key, value)
+                        if this_instruction == 'ENV':
+                            envs[key] = value
+                except KeyError:
+                    # In case we detect key_val_list like [(a,b), None, None,(c,d)]
+                    pass
 
         logger.debug("instructions: %r", instructions)
         return Labels(instructions, self) if name == 'LABEL' else Envs(instructions, self)


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>

This Pull Request fixes error like:
Dockerfile which I used is https://github.com/sclorg/postgresql-container/blob/master/9.5/Dockerfile
Reproducer in ipython:

~~~
import dockerfile_parse DockerfileParser
with open('./Dockerfile', "r") as f:
      dfp =DockerfileParser(fileobj=f)
      dfp_structure = dfp.structure
      for label in dfp.labels:
           print(label)
~~~

where key_val_list looks like:
~~~
key_val_list [(u'summary', u'PostgreSQL'), None, None, None, None, None, None, None, (u'description', u"PostgreSQL is an advanced Object-Relational database management system (DBMS). The image contains the client and server programs that you'll need to create, run, maintain and access a PostgreSQL DBMS server."), (u'io.k8s.description', u"PostgreSQL is an advanced Object-Relational database management system (DBMS). The image contains the client and server programs that you'll need to create, run, maintain and access a PostgreSQL DBMS server."), (u'io.k8s.display-name', u'PostgreSQL 9.5'), (u'io.openshift.expose-services', u'5432:postgresql'), (u'io.openshift.tags', u'database,postgresql,postgresql95,rh-postgresql95'), (u'name', u'centos/postgresql-95-centos7'), (u'com.redhat.component', u'rh-postgresql95-docker'), (u'version', u'9.5'), (u'usage', u'docker run -d --name postgresql_database -e POSTGRESQL_USER=user -e POSTGRESQL_PASSWORD=pass -e POSTGRESQL_DATABASE=db -p 5432:5432 centos/postgresql-95-centos7'), (u'maintainer', u'SoftwareCollections.org <sclorg@redhat.com>')]
~~~