### PR TITLE
fix parsing multiline unquoted labels/envs

### DIFF
--- a/dockerfile_parse/util.py
+++ b/dockerfile_parse/util.py
@@ -225,9 +225,15 @@ def extract_labels_or_envs(env_replace, envs, instruction_value):
         key_val_list.append((key, val))
 
     else:  # LABEL/ENV "name"="value"
-
+        last_item = ""
         for k_v in shlex_splits_raw:
-            key_val_list.append(split_tuple(k_v))
+            if '=' not in k_v:
+                last_item += " " + k_v
+            else:
+                if last_item:
+                    key_val_list.append(split_tuple(last_item))
+                last_item = k_v
+        key_val_list.append(split_tuple(last_item))
 
     return key_val_list
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -694,3 +694,41 @@ class TestDockerfileParser(object):
             LABEL component="$NAME$VER"
         """)
         assert dfparser.labels['component'] == 'name1'
+
+    def test_multiline(self, dfparser):
+        dfparser.content = dedent("""
+            LABEL a=b c d e \
+                  b="parsing is so hard" \
+                  c=y e s
+        """)
+        assert dfparser.labels == {
+            "a": "b c d e",
+            "b": "parsing is so hard",
+            "c": "y e s"
+        }
+
+    def test_multiline2(self, dfparser):
+        dfparser.content = dedent("""
+            LABEL a="b c" \
+                  b=parsing is so hard \
+                  c="y e s"
+        """)
+        assert dfparser.labels == {
+            "a": "b c",
+            "b": "parsing is so hard",
+            "c": "y e s"
+        }
+
+    def test_multispace_label(self, dfparser):
+        # this fails with docker but succeeds with us b/c shlex.split eats consecutive spaces
+        dfparser.content = "LABEL a=b  c"
+        assert dfparser.labels == {"a": "b c"}
+
+    def test_broken_multiline_label(self, dfparser):
+        # once again, shlex.split is smarter than dockerd's parser
+        dfparser.content = dedent("""
+            LABEL a=b \
+                  c
+        """)
+        assert dfparser.labels == {"a": "b c"}
+


### PR DESCRIPTION
Fixes #28

All tests were parsing, I mean passing, for me locally.