### PR TITLE
add newline if necessary when adding instructions

### DIFF
--- a/dockerfile_parse/parser.py
+++ b/dockerfile_parse/parser.py
@@ -528,6 +528,8 @@ class DockerfileParser(object):
             new_line = '{0} {1}\n'.format(instruction, value)
         if new_line:
             lines = self.lines
+            if not lines[len(lines) - 1].endswith('\n'):
+                new_line = '\n' + new_line
             lines += new_line
             self.lines = lines
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -748,3 +748,18 @@ class TestDockerfileParser(object):
         ])
         with pytest.raises(Exception):
             dfparser.labels
+
+    def test_remove_whitespace(self, tmpdir):
+        """
+        Verify keys are parsed correctly even if there is no final newline.
+
+        """
+        with open(os.path.join(str(tmpdir), 'Dockerfile'), 'w') as fp:
+            fp.write('FROM scratch')
+        tmpdir_path = str(tmpdir.realpath())
+        df1 = DockerfileParser(tmpdir_path)
+        df1.labels['foo'] = 'bar'
+
+        df2 = DockerfileParser(tmpdir_path, True)
+        assert df2.baseimage == 'scratch'
+        assert df2.labels['foo'] == 'bar'


### PR DESCRIPTION
If the existing lines do not end with \n, make sure they do.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>