### PR TITLE
Disable F26 and enable F28 for unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,16 @@ env:
       OS_VERSION=7
       PYTHON_VERSION=2
     - OS=fedora
-      OS_VERSION=26
+      OS_VERSION=27
       PYTHON_VERSION=2
     - OS=fedora
-      OS_VERSION=26
+      OS_VERSION=27
       PYTHON_VERSION=3
     - OS=fedora
-      OS_VERSION=27
+      OS_VERSION=28
       PYTHON_VERSION=2
     - OS=fedora
-      OS_VERSION=27
+      OS_VERSION=28
       PYTHON_VERSION=3
 script:
  - pip install coveralls


### PR DESCRIPTION
Fedora 26 is EOL and F28 has been released for a few weeks.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>