### PR TITLE
Create default tito config.

### DIFF
--- a/.tito/packages/.readme
+++ b/.tito/packages/.readme
@@ -1,0 +1,3 @@
+the .tito/packages directory contains metadata files
+named after their packages. Each file has the latest tagged
+version and the project's relative directory.

--- a/.tito/tito.props
+++ b/.tito/tito.props
@@ -1,0 +1,5 @@
+[buildconfig]
+builder = tito.builder.Builder
+tagger = tito.tagger.VersionTagger
+changelog_do_not_remove_cherrypick = 0
+changelog_format = %s (%ae)

--- a/test.sh
+++ b/test.sh
@@ -64,7 +64,14 @@ $RUN $PIP install -r tests/requirements.txt
 
 # CentOS needs to have setuptools updates to make pytest-cov work
 if [[ $OS != "fedora" ]]; then
-  $RUN $PIP install -U setuptools
+  if [[ $OS_VERSION != '6' ]] ; then
+      $RUN $PIP install -U setuptools
+  else
+      # setuptools 40.0 is incompatible with Python 2.6 because of this change
+      # https://github.com/pypa/setuptools/commit/7392f0#diff-c6950cefad8b244938b76f24a0db9a6aR51
+      $RUN $PIP install -U setuptools==39.2.0
+  fi
+
   # Watch out for https://github.com/pypa/setuptools/issues/937
   $RUN curl -O https://bootstrap.pypa.io/2.6/get-pip.py
   $RUN $PYTHON get-pip.py


### PR DESCRIPTION
This fixes COPR build for RHEL7: https://copr.fedorainfracloud.org/coprs/alcmb/osbs-buildroot-update/build/777034/ 