### PR TITLE
initial implementation of comment instructions in DockerfileParser.structure

### DIFF
--- a/dockerfile_parse/constants.py
+++ b/dockerfile_parse/constants.py
@@ -14,3 +14,4 @@ from sys import version_info
 PY2 = version_info[0] == 2
 
 DOCKERFILE_FILENAME = 'Dockerfile'
+COMMENT_INSTRUCTION = 'COMMENT'

--- a/dockerfile_parse/parser.py
+++ b/dockerfile_parse/parser.py
@@ -16,7 +16,7 @@ import re
 from contextlib import contextmanager
 from six import string_types
 
-from .constants import DOCKERFILE_FILENAME
+from .constants import DOCKERFILE_FILENAME, COMMENT_INSTRUCTION
 from .util import (b2u, extract_labels_or_envs, get_key_val_dictionary,
                    u2b, Context, WordSplitter)
 
@@ -216,8 +216,6 @@ class DockerfileParser(object):
              "content": "CMD yum -y update && \\\n    yum clean all\n",
              "value": "yum -y update && yum clean all"}
         ]
-
-        Comments are ignored.
         """
         def _rstrip_backslash(l):
             l = l.rstrip()
@@ -225,37 +223,62 @@ class DockerfileParser(object):
                 return l[:-1]
             return l
 
+        def _create_instruction_dict(instruction=None, value=None):
+            return {
+                'instruction': instruction,
+                'startline': lineno,
+                'endline': lineno,
+                'content': line,
+                'value': value
+            }
+
+        def _clean_comment_line(line):
+            line = re.sub('^\s*#\s*', '', line)
+            line = re.sub('\n', '', line)
+            return line
+
+
         instructions = []
         lineno = -1
         insnre = re.compile(r'^\s*(\w+)\s+(.*)$')  # matched group is insn
         contre = re.compile(r'^.*\\\s*$')          # line continues?
         commentre = re.compile(r'^\s*#')           # line is a comment?
+        
         in_continuation = False
         current_instruction = None
+
         for line in self.lines:
             lineno += 1
-            if commentre.match(line):
-                continue
-            if not in_continuation:
-                m = insnre.match(line)
-                if not m:
-                    continue
-                current_instruction = {'instruction': m.groups()[0].upper(),
-                                       'startline': lineno,
-                                       'endline': lineno,
-                                       'content': line,
-                                       'value': _rstrip_backslash(m.groups()[1])}
-            else:
-                current_instruction['content'] += line
-                current_instruction['endline'] = lineno
-                if current_instruction['value']:
-                    current_instruction['value'] += _rstrip_backslash(line)
-                else:
-                    current_instruction['value'] = _rstrip_backslash(line.lstrip())
 
-            in_continuation = contre.match(line)
-            if not in_continuation and current_instruction is not None:
-                instructions.append(current_instruction)
+            # It is necessary to keep instructions and comment parsing separate,
+            # as a multi-line instruction can be interjected with comments.
+            if commentre.match(line):
+                comment = _create_instruction_dict(
+                    instruction=COMMENT_INSTRUCTION,
+                    value=_clean_comment_line(line)
+                )
+                instructions.append(comment)
+
+            else:
+                if not in_continuation:
+                    m = insnre.match(line)
+                    if not m:
+                        continue
+                    current_instruction = _create_instruction_dict(
+                        instruction=m.groups()[0].upper(), 
+                        value=_rstrip_backslash(m.groups()[1])
+                    )
+                else:
+                    current_instruction['content'] += line
+                    current_instruction['endline'] = lineno
+                    if current_instruction['value']:
+                        current_instruction['value'] += _rstrip_backslash(line)
+                    else:
+                        current_instruction['value'] = _rstrip_backslash(line.lstrip())
+
+                in_continuation = contre.match(line)
+                if not in_continuation and current_instruction is not None:
+                    instructions.append(current_instruction)
 
         return instructions
 


### PR DESCRIPTION
Here is a first pass at implementing **COMMENT** instruction. 

- I decided to treat `value` as all the lines of the comment combined into a clean string, with "# " and new lines stripped. e.g. : 
```
# bla
#   blo
```
becomes 
```
'bla blo'
```
- I used private inlined functions in `structure` in order to avoid repetition, but this calls for a refactor. I didn't dare to do something too radical as I don't know how you see things should be. I'd recommend having `Instruction` and `Comment` as classes (e.g. subclasses of `dict`), and these inline functions could be methods.

Please let me know how this looks, I can push some fixes if needed.